### PR TITLE
增加getInitialMessage方法，使app刚启动未注册listener时可以获取消息

### DIFF
--- a/android/src/main/java/org/wonday/aliyun/push/AliyunPushMessageReceiver.java
+++ b/android/src/main/java/org/wonday/aliyun/push/AliyunPushMessageReceiver.java
@@ -9,6 +9,7 @@
 package org.wonday.aliyun.push;
 
 import android.content.Context;
+import android.util.Log;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -161,10 +162,14 @@ public class AliyunPushMessageReceiver extends MessageReceiver {
 
     private void sendEvent(String eventName, @Nullable WritableMap params) {
         if (context == null) {
+            params.putString("appState", "background");
+            initialMessage = params;
             FLog.d(ReactConstants.TAG, "reactContext==null");
         }else{
             context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);
         }
     }
+    public static WritableMap initialMessage = null;
+
 }

--- a/android/src/main/java/org/wonday/aliyun/push/AliyunPushModule.java
+++ b/android/src/main/java/org/wonday/aliyun/push/AliyunPushModule.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.Context;
 import android.os.Handler;
+import android.util.Log;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -277,4 +278,8 @@ public class AliyunPushModule extends ReactContextBaseJavaModule implements Life
 
     }
 
+    @ReactMethod
+    public void getInitialMessage(final Promise promise){
+        promise.resolve(AliyunPushMessageReceiver.initialMessage);
+    }
 }

--- a/index.js
+++ b/index.js
@@ -43,6 +43,25 @@ export default class AliyunPush {
         return AliyunPushNative.getDeviceId();
     }
 
+    static getInitialMessage = () => {
+        return AliyunPushNative.getInitialMessage().then(e => {
+            if(e && e.extraStr) {
+                let extras = JSON.parse(e.extraStr);
+                if (extras) {
+                    if (extras.badge) {
+                        let badgeNumber = parseInt(extras.badge);
+                        if (!isNaN(badgeNumber)) {
+                            AliyunPush.setApplicationIconBadgeNumber(badgeNumber);
+                        }
+                    }
+                    e.extras = extras;
+                }
+                delete e.extraStr;
+            }
+            return e;
+        });
+    }
+
     static getApplicationIconBadgeNumber = (callback) => {
         AliyunPushNative.getApplicationIconBadgeNumber(function(args) {
             callback(args);


### PR DESCRIPTION
现在app在未启动时收到通知后，点击通知后启动app, 
由于此时JS还没准备好，未注册listener，这个消息无法被正确处理.

改进后的版本：
在向js发消息时，如果JS没准备好，或者没注册listener，则先临时保存该消息，并提供getInitalMessage方法可以获取，在app的JS逻辑完成后可以继续处理该消息

使用的场景：

```
async componentDidMount() {
    //监听推送事件
    AliyunPush.addListener(this.handleAliyunPushMessage);
    this.ready = true;
    const msg = await AliyunPush.getInitialMessage();
    if(msg){
        this.handleAliyunPushMessage(msg);
    }
}

componentWillUnmount() {
    AliyunPush.removeListener(this.handleAliyunPushMessage);
}
handleAliyunPushMessage = (e) => {
    if(!this.ready){
        return false;
    }
    .....
}
```

