### PR TITLE
rn 0.60+ 开始  ios 默认是 pod 配置的。加个一个 pod 的配置文件

### DIFF
--- a/RCTAliyunPush.podspec
+++ b/RCTAliyunPush.podspec
@@ -9,10 +9,14 @@ Pod::Spec.new do |spec|
   spec.homepage     = "https://github.com/a188658587/react-native-aliyun-push"
   spec.license      = "MIT"
   spec.author             = { "wwwlin" => "188658587@qq.com" }
-  spec.ios.deployment_target = "7.0"
+  spec.ios.deployment_target = "9.0"
   spec.tvos.deployment_target = "9.0"
   spec.source         = { :git => 'https://github.com/a188658587/react-native-aliyun-push.git', :tag => "v#{spec.version}"}
   spec.source_files  =  "ios/**/*.{h,m}"
+  spec.vendored_frameworks = "ios/libs/AlicloudUtils.framework","ios/libs/CloudPushSDK.framework","ios/libs/UTDID.framework","ios/libs/UTMini.framework"
+  spec.libraries = "z", "resolv", "sqlite3"
+
+  spec.requires_arc = true
 
   spec.dependency "React"
 end

--- a/RCTAliyunPush.podspec
+++ b/RCTAliyunPush.podspec
@@ -1,0 +1,18 @@
+require "json"
+version = JSON.parse(File.read("package.json"))["version"]
+
+Pod::Spec.new do |spec|
+
+  spec.name         = "RCTAliyunPush"
+  spec.version      = version
+  spec.summary      = "A short description of RCTAliyunPush."
+  spec.homepage     = "https://github.com/a188658587/react-native-aliyun-push"
+  spec.license      = "MIT"
+  spec.author             = { "wwwlin" => "188658587@qq.com" }
+  spec.ios.deployment_target = "7.0"
+  spec.tvos.deployment_target = "9.0"
+  spec.source         = { :git => 'https://github.com/a188658587/react-native-aliyun-push.git', :tag => "v#{spec.version}"}
+  spec.source_files  =  "ios/**/*.{h,m}"
+
+  spec.dependency "React"
+end


### PR DESCRIPTION
rn 0.60+ 开始  ios 默认是 pod 配置的。所以加个一个 pod 的配置文件，
在   yarn add react-native-aliyun-push  
之后 
cd ios && pod install
ios可以配置上
但是初始化还是要做的。


第一次提交请求，可能不符合规则，见谅。